### PR TITLE
Add TikTok repost command with download cleanup

### DIFF
--- a/commands/tiktok.js
+++ b/commands/tiktok.js
@@ -1,0 +1,82 @@
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
+
+module.exports = {
+  name: "tiktok",
+  description:
+    "Download a TikTok and repost it in the same channel, then delete the local file",
+  usage: ",tiktok <tiktok_link>",
+  execute(message, args) {
+    const run = async () => {
+      const tiktokUrl = args[1];
+
+      if (!tiktokUrl) {
+        message.channel
+          .send(`${message.author} | Usage: \`,tiktok <tiktok_link>\``)
+          .then((msg) => setTimeout(() => msg.delete(), 7000));
+        return;
+      }
+
+      const isTikTokLink = /(?:https?:\/\/)?(?:www\.)?(?:tiktok\.com|vm\.tiktok\.com|vt\.tiktok\.com)\//i.test(
+        tiktokUrl
+      );
+
+      if (!isTikTokLink) {
+        message.channel
+          .send(`${message.author} | Please provide a valid TikTok URL.`)
+          .then((msg) => setTimeout(() => msg.delete(), 7000));
+        return;
+      }
+
+      const downloadDir = path.join(__dirname, "..", "downloads");
+      if (!fs.existsSync(downloadDir)) fs.mkdirSync(downloadDir, { recursive: true });
+
+      const filename = `tiktok_${Date.now()}.mp4`;
+      const filePath = path.join(downloadDir, filename);
+
+      try {
+        const apiResponse = await axios.get("https://www.tikwm.com/api/", {
+          params: { url: tiktokUrl, hd: 1 },
+          timeout: 15000,
+        });
+
+        const videoUrl = apiResponse?.data?.data?.hdplay || apiResponse?.data?.data?.play;
+
+        if (!videoUrl) {
+          throw new Error("Could not resolve downloadable TikTok video URL.");
+        }
+
+        const videoResponse = await axios.get(videoUrl, {
+          responseType: "stream",
+          timeout: 60000,
+        });
+
+        await new Promise((resolve, reject) => {
+          const writer = fs.createWriteStream(filePath);
+          videoResponse.data.pipe(writer);
+          writer.on("finish", resolve);
+          writer.on("error", reject);
+        });
+
+        await message.channel.send({
+          content: `Requested by ${message.author}`,
+          files: [filePath],
+        });
+      } catch (error) {
+        console.log(error);
+        message.channel
+          .send(`${message.author} | Failed to download/post that TikTok.`)
+          .then((msg) => setTimeout(() => msg.delete(), 7000));
+      } finally {
+        if (fs.existsSync(filePath)) {
+          fs.unlink(filePath, (unlinkErr) => {
+            if (unlinkErr) console.log(unlinkErr);
+          });
+        }
+      }
+    };
+
+    run();
+  },
+};


### PR DESCRIPTION
### Motivation
- Provide a simple command to let users repost a TikTok into the same channel by downloading the video, sending it as a message attachment, and removing the temporary file.
- Ensure the bot validates input URLs and always removes on-disk artifacts to avoid filling disk space.

### Description
- Add new command file `commands/tiktok.js` which implements a `,tiktok <tiktok_link>` command. 
- Validate the provided URL with a TikTok-specific regex and return usage/error messages when input is missing or invalid. 
- Resolve a downloadable video URL via the TikWM API, stream the video to `downloads/tiktok_<timestamp>.mp4`, and send it to the same channel with `message.channel.send({ files: [filePath] })`.
- Always remove the temporary file in a `finally` block after success or failure to guarantee cleanup.

### Testing
- Ran `node --check commands/tiktok.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d005464bb8833099324f767d30f7c4)